### PR TITLE
Allow users to add optional comments when submitting a review

### DIFF
--- a/docs/datamodel.md
+++ b/docs/datamodel.md
@@ -21,6 +21,7 @@ erDiagram
     Int rating 
     DateTime createdAt 
     String createdBy "🗝️"
+    String comment 
     }
   
 

--- a/prisma/migrations/20240819084732_add_comment_to_review/migration.sql
+++ b/prisma/migrations/20240819084732_add_comment_to_review/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - Added the required column `comment` to the `Review` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Review" (
+    "restaurantId" INTEGER NOT NULL,
+    "rating" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdBy" TEXT NOT NULL,
+    "comment" TEXT NOT NULL,
+
+    PRIMARY KEY ("restaurantId", "createdBy"),
+    CONSTRAINT "Review_restaurantId_fkey" FOREIGN KEY ("restaurantId") REFERENCES "Restaurant" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Review" ("createdAt", "createdBy", "rating", "restaurantId") SELECT "createdAt", "createdBy", "rating", "restaurantId" FROM "Review";
+DROP TABLE "Review";
+ALTER TABLE "new_Review" RENAME TO "Review";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,7 @@ model Review {
   rating        Int
   createdAt     DateTime     @default(now())
   createdBy     String
+  comment       String
 
   @@id([restaurantId, createdBy])
 }

--- a/src/app/restaurant/[id]/page.tsx
+++ b/src/app/restaurant/[id]/page.tsx
@@ -42,6 +42,7 @@ const RestaurantsPage = (props: { params: { id: string } }) => {
               className="flex flex-row justify-between p-2 even:bg-stone-400 dark:even:bg-stone-600"
             >
               <p>Rating: {review.rating}</p>
+              <p>Comment: {review.comment}</p>
               <p className="flex flex-col text-xs text-stone-700 dark:text-stone-300">
                 {new Date(review.createdAt).toLocaleDateString()}
                 {user.sub === review.createdBy ? (

--- a/src/app/restaurant/[id]/page.tsx
+++ b/src/app/restaurant/[id]/page.tsx
@@ -30,7 +30,7 @@ const RestaurantsPage = (props: { params: { id: string } }) => {
           <RestaurantCard {...data} />
           <Link
             href={`/restaurant/${restaurantId}/review`}
-            className="my-4 rounded bg-red-100 px-4 py-2 font-bold hover:bg-red-300 dark:bg-red-900 hover:dark:bg-red-700"
+            className="my-4 rounded-lg bg-red-100 px-4 py-2 font-bold hover:bg-red-300 dark:bg-red-900 hover:dark:bg-red-700"
           >
             {data.reviews.some((review) => review.createdBy === user.sub)
               ? 'Update your review'
@@ -39,24 +39,27 @@ const RestaurantsPage = (props: { params: { id: string } }) => {
           {data.reviews.map((review) => (
             <div
               key={review.createdBy}
-              className="flex flex-row justify-between p-2 even:bg-stone-400 dark:even:bg-stone-600"
+              className="flex flex-col p-4 mb-4 rounded-lg bg-stone-100 dark:bg-stone-800"
             >
-              <p>Rating: {review.rating}</p>
-              <p>Comment: {review.comment}</p>
-              <p className="flex flex-col text-xs text-stone-700 dark:text-stone-300">
-                {new Date(review.createdAt).toLocaleDateString()}
-                {user.sub === review.createdBy ? (
-                  <span className="text-red-700 dark:text-red-300">
-                    Your review
-                  </span>
-                ) : null}
-              </p>
+              <div className="flex items-center justify-between">
+                <p className="font-semibold">Rating: {review.rating}</p>
+                <p className="text-xs text-stone-700 dark:text-stone-300">
+                  {new Date(review.createdAt).toLocaleDateString()}
+                </p>
+              </div>
+              <p className="mt-2 text-stone-900 dark:text-stone-100">{review.comment}</p>
+              {user.sub === review.createdBy && (
+                <p className="mt-2 text-xs text-red-700 dark:text-red-300">
+                  Your review
+                </p>
+              )}
             </div>
           ))}
         </>
       )}
     </main>
   );
+  
 };
 
 export default RestaurantsPage;

--- a/src/components/Form/AddReviewForm.tsx
+++ b/src/components/Form/AddReviewForm.tsx
@@ -2,7 +2,7 @@
 import Form from './Form';
 import { z } from 'zod';
 import { ReviewCreateInputSchema } from '@/types/generated';
-import { NumberField, SelectField } from './FormField';
+import { NumberField, TextField, SelectField } from './FormField';
 import { useFormState } from 'react-dom';
 import { addReviewAction } from '@/actions/addReview';
 import { SelectProps } from '../Select';
@@ -22,6 +22,7 @@ const initialState: AddReviewFormState = {
     },
   },
   rating: 0,
+  comment: ""
 };
 
 const AddReviewForm = (props: { restaurantId: number }) => {
@@ -35,6 +36,11 @@ const AddReviewForm = (props: { restaurantId: number }) => {
         id="rating"
         label="Rating"
         name="rating"
+      />
+      <TextField
+        id="comment"
+        label="Comment"
+        name="comment"
       />
     </Form>
   );

--- a/src/services/review.ts
+++ b/src/services/review.ts
@@ -35,6 +35,7 @@ export const addReview = async <State>(
       connect: { id: parseInt(String(formData.get('restaurantId')), 10) },
     },
     rating: parseInt(String(formData.get('rating')), 10),
+    comment: String(formData.get('comment')),
     createdBy: getUserIdFromIdToken(session.idToken),
   };
 
@@ -55,7 +56,10 @@ export const addReview = async <State>(
           createdBy: payload.createdBy,
         },
       },
-      update: { rating: validatedFields.data.rating },
+      update: {
+        rating: validatedFields.data.rating,
+        comment: validatedFields.data.comment
+      },
       create: { ...validatedFields.data },
     });
     return { ...validatedFields.data, errors: undefined };


### PR DESCRIPTION
This PR allows users to add optional comments when submitting a review

- Added a new `comment` field to the `Review` model in the Prisma schema
- Updated the corresponding migration to reflect this change
- Updated UI code and other needed places to allow users to add comments to reviews
- Also some small improvements to restaurant page layout