### PR TITLE
Add permissions to lint workflow to allow PRs from forked repositories

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   checks: write
   contents: write
+  pull-requests: write
 
 jobs:
   run-linters:


### PR DESCRIPTION
Add write permissions to pull requests in lint workflow to allow PRs from forked repositories